### PR TITLE
Add -Zgzip argument

### DIFF
--- a/packages.sh
+++ b/packages.sh
@@ -1,1 +1,1 @@
-dpkg-deb -b Package
+dpkg-deb -Zgzip -b Package


### PR DESCRIPTION
This ensures compatibility with the latest homebrew versions of dpkg, otherwise Cydia will error out on install
